### PR TITLE
Remove prefix from task names

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,19 +1,19 @@
 ---
 
-- name: users | Ensure the groups are present pt. 1
+- name: Ensure the groups are present
   group: name={{item.name|default(item)}} system={{item.system|default("no")}}
   with_items: users_groups
 
-- name: users | Ensure the removed groups are not present
+- name: Ensure the removed groups are not present
   group: name={{item}} state=absent
   with_items: users_remove_groups
 
-- name: users | Create per user groups
+- name: Create per user groups
   group: name={{item.name|default(item)}}
   when: not users_to_install or item.name|default(item) in users_to_install
   with_items: users_users
 
-- name: users | Ensure the users are present
+- name: Ensure the users are present
   user:
       name: "{{item.name|default(item)}}"
       comment: "{{item.comment|default('')}}"
@@ -31,11 +31,11 @@
   when: not users_to_install or item.name|default(item) in users_to_install
   with_items: users_users
 
-- name: users | Ensure the removed users are not present
+- name: Ensure the removed users are not present
   user: name={{item}} state=absent remove=yes
   with_items: users_remove_users
 
-- name: users | Ensure the users ssh keys are present
+- name: Ensure the users ssh keys are present
   authorized_key: "user={{item.0.name}} key='{{item.1}}'"
   when: not users_to_install or item.0.name in users_to_install
   with_subelements:


### PR DESCRIPTION
Remove the `users |` prefix otherwise you end up with logs like this:

```
TASK: [users | users | Ensure the groups are present] *************************
```
