### PR TITLE
Remove force option from present

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -18,7 +18,6 @@
       name: "{{item.name|default(item)}}"
       comment: "{{item.comment|default('')}}"
       createhome: "{{item.createhome|default('yes')}}"
-      force: "{{item.force|default('no')}}"
       group: "{{item.group|default(item.name|default(item))}}"
       groups: "{{item.groups|default('')}}"
       home: "{{item.home|default('/home/' + item.name|default(item))}}"


### PR DESCRIPTION
The force option is only used when using `state=absent`